### PR TITLE
Add domain blocklisting

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,10 +67,10 @@ show_github_link: true
 # Default: false
 selflinks: false
 
-# List: Prevent creation of URLs linking to domains in the blacklist
+# List: Prevent creation of URLs linking to domains in the blocklist
 # Example of list formatting in yaml:
-# blacklist:
-#     - blacklisted.com
-#     - subdomain.blacklisted.net
+# blocklist:
+#     - blocklisted.com
+#     - subdomain.blocklisted.net
 # Default: []
-blacklist: []
+blocklist: []

--- a/config.yml
+++ b/config.yml
@@ -66,3 +66,11 @@ show_github_link: true
 # Boolean: Allow short URLs linking to your site_domain URL
 # Default: false
 selflinks: false
+
+# List: Prevent creation of URLs linking to domains in the blacklist
+# Example of list formatting in yaml:
+# blacklist:
+#     - blacklisted.com
+#     - subdomain.blacklisted.net
+# Default: []
+blacklist: []

--- a/liteshort.py
+++ b/liteshort.py
@@ -38,7 +38,7 @@ def load_config():
         "subdomain": "",
         "latest": "l",
         "selflinks": False,
-        "blacklist": [],
+        "blocklist": [],
     }
 
     config_types = {
@@ -55,7 +55,7 @@ def load_config():
         "subdomain": (str, type(None)),
         "latest": (str, type(None)),
         "selflinks": bool,
-        "blacklist": list,
+        "blocklist": list,
     }
 
     for option in req_options.keys():
@@ -117,17 +117,13 @@ def check_short_exist(short):  # Allow to also check against a long link
     return False
 
 
-def check_self_link(long):
-    if get_baseUrl().rstrip("/") in long:
-        return True
-    return False
-
-
-def linking_to_blacklist(long):
+def linking_to_blocklist(long):
     # Removes protocol and other parts of the URL to extract the domain name
     long = long.split("//")[-1].split("/")[0]
-    if long in current_app.config["blacklist"]:
+    if long in current_app.config["blocklist"]:
         return True
+    if not current_app.config["selflinks"]:
+        return long in get_baseUrl()
     return False
 
 
@@ -338,13 +334,8 @@ def main_post():
         if check_short_exist(short):
             return response(request, None, "Short URL already taken")
         long_exists = check_long_exist(request.form["long"])
-        if (
-            check_self_link(request.form["long"])
-            and not current_app.config["selflinks"]
-        ):
+        if linking_to_blocklist(request.form["long"]):
             return response(request, None, "You cannot link to this site")
-        if linking_to_blacklist(request.form["long"]):
-            return response(request, None, "You cannot link to this blacklisted site")
         if long_exists and not request.form.get("short"):
             set_latest(request.form["long"])
             get_db().commit()


### PR DESCRIPTION
Add domain blocklisting with the list of blocked domains configurable in `config.yml`. The list defaults to `[]` (empty), but an example of the YAML formatting for it is provided.